### PR TITLE
Workaround for menu clipping

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,19 +1,26 @@
 {
   // See https://go.microsoft.com/fwlink/?LinkId=733558
   // for the documentation about the tasks.json format
-  "version": "0.1.0",
+  "version": "2.0.0",
   "command": "npm",
-  "isShellCommand": true,
-  "showOutput": "always",
-  "suppressTaskName": true,
   "tasks": [
     {
-      "taskName": "server:build",
-      "args": ["run", "server:build"]
+      "label": "server:build",
+      "type": "shell",
+      "args": [
+        "run",
+        "server:build"
+      ],
+      "problemMatcher": []
     },
     {
-      "taskName": "client:build",
-      "args": ["run", "client:build"]
+      "label": "client:build",
+      "type": "shell",
+      "args": [
+        "run",
+        "client:build"
+      ],
+      "problemMatcher": []
     }
   ]
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,13 +14,9 @@ pipeline {
                 branch 'master'
             }
             steps {
-                sh "docker tag ${GIT_COMMIT} dtr.fintlabs.no/beta/information-model-documentation-portal:build.${BUILD_NUMBER}"
-                withDockerRegistry([credentialsId: 'dtr-fintlabs-no', url: 'https://dtr.fintlabs.no']) {
-                    sh "docker push dtr.fintlabs.no/beta/information-model-documentation-portal:build.${BUILD_NUMBER}"
-                }
-                sh "docker tag ${GIT_COMMIT} fintlabs.azurecr.io/information-model-documentation-portal:build.${BUILD_NUMBER}"
-                withDockerRegistry([credentialsId: 'fintlabs.azurecr.io', url: 'https://fintlabs.azurecr.io']) {
-                    sh "docker push fintlabs.azurecr.io/information-model-documentation-portal:build.${BUILD_NUMBER}"
+                sh "docker tag ${GIT_COMMIT} fintlabsacr.azurecr.io/information-model-documentation-portal:build.${BUILD_NUMBER}"
+                withDockerRegistry([credentialsId: 'fintlabsacr.azurecr.io', url: 'https://fintlabsacr.azurecr.io']) {
+                    sh "docker push fintlabsacr.azurecr.io/information-model-documentation-portal:build.${BUILD_NUMBER}"
                 }
             }
         }

--- a/client/app/views/model/model.component.scss
+++ b/client/app/views/model/model.component.scss
@@ -66,7 +66,7 @@
     overflow: hidden;
     transition: max-height 0.4s ease-in-out;
     &.visible {
-      max-height: 2000px;
+      max-height: max-content;
     }
   }
   ul {

--- a/client/app/views/model/model.component.scss
+++ b/client/app/views/model/model.component.scss
@@ -66,7 +66,7 @@
     overflow: hidden;
     transition: max-height 0.4s ease-in-out;
     &.visible {
-      max-height: 1000px;
+      max-height: 2000px;
     }
   }
   ul {


### PR DESCRIPTION
In my testing, `max-height` seems to be the cause for the right-hand menu clipping.  Disabling the attribute hides the menu, so it is apparently important for some reason.

The current height value is around 1200px in my Chrome, and setting max-height to 2000 did not seem to have any adversary effects.